### PR TITLE
Fix build command in README to reference the correct main file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/trapcodeio/envfinder.git
 cd envfinder
 
 # Build the executable
-go build -o envfinder envfinder.go
+go build -o envfinder main.go
 ```
 
 ## 📋 Usage


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects the build command to use `main.go` instead of `envfinder.go` for building the executable.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Updated the build command to use `main.go` instead of `envfinder.go`.